### PR TITLE
Poder establecer una ruta de directorio de configuración diferente a 'Default'

### DIFF
--- a/NetCore/Src/Config/Settings.cs
+++ b/NetCore/Src/Config/Settings.cs
@@ -473,6 +473,18 @@ namespace VeriFactu.Config
 
         }
 
+        /// <summary>
+        /// Establece la ruta al directorio de configuración.
+        /// </summary>
+        /// <param name="path">Ruta del directorio de configuración acabada en '/'</param>
+        public static void SetRutaDirectorioConfiguracion(string path)
+        {
+
+            Path = path;
+            Get();
+
+        }
+
         #endregion
 
     }


### PR DESCRIPTION
La ruta por defecto de los archivos de disco se guarda en "C:\ProgramData\VeriFactu".

Poder modificar esta ruta.