### PR TITLE
IdOtro - corrección

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+VerifactuLib ARM64/
+VerifactuLib x64/
+VerifactuLib x86/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaInterlocutor.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaInterlocutor.cs
@@ -153,7 +153,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta
 
                     // Si se identifica a través de la agrupación IDOtro y CodigoPais sea "ES", se validará que el campo IDType sea “03” o “07”..
                     if (_Interlocutor.IDOtro.CodigoPais == CodigoPais.ES && 
-                        (_Interlocutor.IDOtro.IDType != IDType.PASAPORTE || _Interlocutor.IDOtro.IDType != IDType.NO_CENSADO))
+                        (_Interlocutor.IDOtro.IDType != IDType.PASAPORTE && _Interlocutor.IDOtro.IDType != IDType.NO_CENSADO))
                         result.Add($"Error en el bloque RegistroAlta ({_RegistroAlta}):" +
                             $" {_Rol} es obligatorio que para IDOtro.CodigoPais = “{_Interlocutor.IDOtro.CodigoPais}”" +
                             $" IDOtro.IDType = “03” (PASAPORTE) o IDOtro.IDType = “07” (NO_CENSADO).");


### PR DESCRIPTION
Corrección de error en IDOtro: cuando CodigoPais es "ES", habrá error si el IDType es distinto de "pasaporte" Y TAMBIÉN distinto de "no censado". 
(Hasta ahora, había error si IDType era distinto de "pasaporte" o distinto de "no censado").