### PR TITLE
Hacemos público el método estático LoadBlockchainsFromDisk().

### DIFF
--- a/NetCore/Src/Blockchain/Blockchain.cs
+++ b/NetCore/Src/Blockchain/Blockchain.cs
@@ -108,7 +108,7 @@ namespace VeriFactu.Blockchain
         /// <summary>
         /// Carga todas las cadenas de bloques.
         /// </summary>
-        private static void LoadBlockchainsFromDisk()
+        public static void LoadBlockchainsFromDisk()
         {
 
             if (string.IsNullOrEmpty(Settings.Current.BlockchainPath) || !Directory.Exists(Settings.Current.BlockchainPath))


### PR DESCRIPTION
Hasta ahora, si cambiábamos la ruta de las carpetas de configuración, no se producía encadenamiento de facturas porque dicho método se ejecutaba solo una vez con los parámetros predeterminados y buscaba los ficheros de encadenamiento en la carpeta predeterminada. Al hacer público el método, podemos cambiar las rutas y después refrescar blockchains, permitiendo así un encadenamiento correcto de las facturas.

Ejemplo:
            var config = VeriFactu.Config.Settings.Current;
            //Rutas
            config.BlockchainPath = BasePath + @"\BlockChains\";
            config.InboxPath = BasePath + @"\Inbox\";
            config.InvoicePath = InvoicePath;
            config.LogPath = BasePath + @"\Log\";
            config.OutboxPath = BasePath + @"\Outbox\";

         //Recarga el Blockchain si hemos cambiado las propiedades de configuración
            Blockchain.LoadBlockchainsFromDisk();