### PR TITLE
Eliminación de telemetría

### DIFF
--- a/NetCore/Src/Config/Settings.cs
+++ b/NetCore/Src/Config/Settings.cs
@@ -134,8 +134,6 @@ namespace VeriFactu.Config
             BlockchainInitialized = Blockchain.Blockchain.Initialized; // Inicia cadena de bloques
             Current.SistemaInformatico.IndicadorMultiplesOT = Seller.GetSellers().Count > 1 ? "S" : "N"; // Valor multiples OT
 
-            ApiClient.Ct(); 
-
         }
 
         #endregion


### PR DESCRIPTION
Entiendo que aquí, hace 7 meses, se os coló accidentalmente este trozo de código que envía a vuestros servidores de prueba información altamente sensible sin el conocimiento del usuario. Es algo bastante grave. Además, si lo bloqueas vía firewall, te comes 100s de timeout.