### PR TITLE
Update Settings.cs

### DIFF
--- a/NetCore/Src/Config/Settings.cs
+++ b/NetCore/Src/Config/Settings.cs
@@ -79,7 +79,7 @@ namespace VeriFactu.Config
 		/// </summary>
 		static readonly string _Path =
 #if !LE_461
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")) ?
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("OSX")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")) ?
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + $"{_PathSep}VeriFactu{_PathSep}" :
 #endif
             Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + $"{_PathSep}VeriFactu{_PathSep}";


### PR DESCRIPTION
Este cambio permite utilizar la librería en Mac, en lugar de usar /usr/share/VeriFactu (sin permisos de escritura) se usa ~/Library/Application Support/VeriFactu donde no hay problemas de escritura.