### PR TITLE
Definir simbolos de compilación condicional para poder compilar en modo Release

### DIFF
--- a/Interop/Verifactu.Com.ARM64/Verifactu.Com.ARM64.csproj
+++ b/Interop/Verifactu.Com.ARM64/Verifactu.Com.ARM64.csproj
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_480</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/Interop/Verifactu.Com.x64/Verifactu.Com.x64.csproj
+++ b/Interop/Verifactu.Com.x64/Verifactu.Com.x64.csproj
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_480</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/Interop/Verifactu.Com.x86/Verifactu.Com.x86.csproj
+++ b/Interop/Verifactu.Com.x86/Verifactu.Com.x86.csproj
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_480</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NetFramework/VeriFactu.NetFramework.csproj
+++ b/NetFramework/VeriFactu.NetFramework.csproj
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_480</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NetFramework461/VeriFactu.NetFramework461.csproj
+++ b/NetFramework461/VeriFactu.NetFramework461.csproj
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_461</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/NetFramework472/VeriFactu.NetFramework472.csproj
+++ b/NetFramework472/VeriFactu.NetFramework472.csproj
@@ -29,7 +29,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;LE_472</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
Al intentar compilar en modo Release me daba unos errores y he visto que en todas las ramas de .Net Framework había definidos unos símbolos de compilación en modo Debug pero faltaban en Release, así que simplemente las he copiado.  

Esto además me hace pensar ¿las dlls que se distribuyen en NuGet están compiladas en modo Debug o Release?