### PR TITLE
Actualizar System.Security.Cryptography.Xml a 9.0.16 (CVE-2026-26171 y CVE-2026-33116)

### DIFF
--- a/NetCore/VeriFactu.Net.Core.csproj
+++ b/NetCore/VeriFactu.Net.Core.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.16" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
El archivo NetCore/VeriFactu.Net.Core.csproj referencia actualmente System.Security.Cryptography.Xml en su versión 9.0.0, que  tiene dos avisos de seguridad de severidad alta (CVSS 7.5, ambos de denegación de servicio por consumo descontrolado de recursos en la clase EncryptedXml):

- GHSA-37gx-xxp4-5rgx / CVE-2026-33116 (bucle infinito)
- GHSA-w3x6-4m5h-cxqf / CVE-2026-26171 (consumo descontrolado de recursos)

Rango afectado: 9.0.0 a 9.0.14. Primera versión parcheada: 9.0.15. Este PR sube a 9.0.16, la última versión estable de la serie 9.x al escribir esto.