### PR TITLE
Corregir condición invertida en validadores de Huella (Alta y Anulación)

### DIFF
--- a/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaHuella.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaHuella.cs
@@ -83,7 +83,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta
             if (_RegistroAlta.Encadenamiento == null ||_RegistroAlta.Encadenamiento.PrimerRegistro == "S")
                 return result;
 
-            if (Regex.IsMatch(_RegistroAlta.Encadenamiento.RegistroAnterior.Huella, @"[0-9ABCDEF]{64}"))
+            if (!Regex.IsMatch(_RegistroAlta.Encadenamiento.RegistroAnterior.Huella, @"^[0-9ABCDEF]{64}$"))
                 result.Add($"[3.1.3-18.0] Error en el bloque RegistroAlta ({_RegistroAlta}):" +
                     $" La huella del encadenamiento del registro anterior debe cumplir el formato de salida" +
                     $" del algoritmo SHA-256, siendo de 64 caracteres en hexadecimal y en mayúsculas");

--- a/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionHuella.cs
+++ b/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionHuella.cs
@@ -83,8 +83,8 @@ namespace VeriFactu.Business.Validation.Validators.Anulacion
             if (_RegistroAnulacion.Encadenamiento == null ||_RegistroAnulacion.Encadenamiento.PrimerRegistro == "S")
                 return result;
 
-            if (Regex.IsMatch(_RegistroAnulacion.Encadenamiento.RegistroAnterior.Huella, @"[0-9ABCDEF]{64}"))
-                result.Add($"[3.1.4-4.0] Error en el bloque RegistroAlta ({_RegistroAnulacion}):" +
+            if (!Regex.IsMatch(_RegistroAnulacion.Encadenamiento.RegistroAnterior.Huella, @"^[0-9ABCDEF]{64}$"))
+                result.Add($"[3.1.4-4.0] Error en el bloque RegistroAnulacion ({_RegistroAnulacion}):" +
                     $" La huella del encadenamiento del registro anterior debe cumplir el formato de salida" +
                     $" del algoritmo SHA-256, siendo de 64 caracteres en hexadecimal y en mayúsculas");
 


### PR DESCRIPTION
Los validadores de Huella tenían la condición invertida: rechazaban toda huella SHA-256 válida y aceptaban las malformadas. Defecto 1 de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes