### PR TITLE
Hacer seguro entre hilos el cálculo de huellas y el registro de instancias por clave

### DIFF
--- a/NetCore/Src/Common/SingletonByKey.cs
+++ b/NetCore/Src/Common/SingletonByKey.cs
@@ -62,6 +62,13 @@ namespace VeriFactu.Common
         /// </summary>
         static readonly Dictionary<string, SingletonByKey<T>> _InstancesLoaded = new Dictionary<string, SingletonByKey<T>>();
 
+        /// <summary>
+        /// Sincroniza el acceso al diccionario de instancias: sin él, dos hilos
+        /// pueden superar a la vez la comprobación de existencia y el segundo
+        /// termina en ArgumentException (o corrompe el diccionario).
+        /// </summary>
+        static readonly object _Lock = new object();
+
         #endregion
 
         #region Construtores de Instancia
@@ -75,8 +82,14 @@ namespace VeriFactu.Common
 
             var tKey = key.Trim();
 
-            Check(tKey);
-            Register(tKey);
+            // lock reentrante: la creación desde GetInstance ya posee el cerrojo
+            lock (_Lock)
+            {
+
+                Check(tKey);
+                Register(tKey);
+
+            }
 
             Key = tKey;
 
@@ -96,10 +109,15 @@ namespace VeriFactu.Common
         protected static SingletonByKey<T> GetInstance(string key)
         {
 
-            if (_InstancesLoaded.ContainsKey(key))
-                return _InstancesLoaded[key];
+            lock (_Lock)
+            {
 
-            return Activator.CreateInstance(typeof(T), new object[] { key }) as SingletonByKey<T>;
+                if (_InstancesLoaded.ContainsKey(key))
+                    return _InstancesLoaded[key];
+
+                return Activator.CreateInstance(typeof(T), new object[] { key }) as SingletonByKey<T>;
+
+            }
 
         }
 

--- a/NetCore/Src/Common/Utils.cs
+++ b/NetCore/Src/Common/Utils.cs
@@ -56,12 +56,15 @@ namespace VeriFactu.Common
         #region Variables Privadas Estáticas
 
         /// <summary>
-        /// Algoritmos de digest disponibles.
+        /// Fábricas de algoritmos de digest disponibles. Se crea una instancia
+        /// nueva por cálculo: HashAlgorithm mantiene estado interno y compartir
+        /// una única instancia entre hilos corrompe los hashes calculados en
+        /// paralelo (la huella de la cadena de bloques).
         /// </summary>
-        static readonly Dictionary<TipoHuella, HashAlgorithm> _HashAlgorithms = new Dictionary<TipoHuella, HashAlgorithm>()
+        static readonly Dictionary<TipoHuella, Func<HashAlgorithm>> _HashAlgorithms = new Dictionary<TipoHuella, Func<HashAlgorithm>>()
         {
 
-            {TipoHuella.Sha256, new SHA256Managed() }
+            {TipoHuella.Sha256, () => SHA256.Create() }
 
         };
 
@@ -74,11 +77,6 @@ namespace VeriFactu.Common
             {"UTF-8", Encoding.UTF8 }
 
         };
-
-        /// <summary>
-        /// Algoritmo de hash.
-        /// </summary>
-        internal static HashAlgorithm HashAlgorithm { get; private set; }
 
         /// <summary>
         /// Encoding del texto de entrada para el hash de hash.
@@ -108,10 +106,27 @@ namespace VeriFactu.Common
                 throw new ArgumentException($"El valor de la variable de configuración 'VeriFactuHashInputEncoding'" +
                     $" no puede ser '{Settings.Current.VeriFactuHashInputEncoding}'.");
 
-            HashAlgorithm = _HashAlgorithms[Settings.Current.VeriFactuHashAlgorithm];
             Encoding = _Encodings[Settings.Current.VeriFactuHashInputEncoding];
 
             Logger = new Logger();
+
+        }
+
+        #endregion
+
+        #region Métodos Internos Estáticos
+
+        /// <summary>
+        /// Calcula el hash de la entrada con el algoritmo configurado,
+        /// usando una instancia nueva por llamada (seguro entre hilos).
+        /// </summary>
+        /// <param name="input">Bytes de entrada.</param>
+        /// <returns>Hash calculado.</returns>
+        internal static byte[] ComputeHash(byte[] input)
+        {
+
+            using (var hashAlgorithm = _HashAlgorithms[Settings.Current.VeriFactuHashAlgorithm]())
+                return hashAlgorithm.ComputeHash(input);
 
         }
 

--- a/NetCore/Src/Xml/Factu/Registro.cs
+++ b/NetCore/Src/Xml/Factu/Registro.cs
@@ -111,7 +111,7 @@ namespace VeriFactu.Xml.Factu
         {
 
             var binInput = GetHashInput();
-            var hash = Utils.HashAlgorithm.ComputeHash(binInput);
+            var hash = Utils.ComputeHash(binInput);
 
             return hash;
 


### PR DESCRIPTION
El cálculo de huella usaba una instancia SHA256 estática compartida entre hilos (corrompe la huella bajo concurrencia), y SingletonByKey no estaba sincronizado. Defecto 2 de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes