### PR TITLE
Corregir condiciones de polaridad en validadores de IDOtro

### DIFF
--- a/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionGenerador.cs
+++ b/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionGenerador.cs
@@ -119,7 +119,7 @@ namespace VeriFactu.Business.Validation.Validators.Anulacion
                         $" {_RegistroAnulacion.GeneradoPor}: Si se identifica a través de la agrupación IDOtro y CodigoPais sea 'ES', se validará que el campo IDType sea “03”.");
 
                     // No se admite el tipo de identificación IDType “07” (“No censado”).
-                    if (_RegistroAnulacion.Generador?.IDOtro?.IDType != IDType.NO_CENSADO)
+                    if (_RegistroAnulacion.Generador?.IDOtro?.IDType == IDType.NO_CENSADO)
                         result.Add($"[3.1.4-3.4] Error en el bloque RegistroAnulacion ({_RegistroAnulacion}):" +
                         $" {_RegistroAnulacion.GeneradoPor}: No se admite el tipo de identificación IDType “07” (“No censado”).");
 

--- a/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionInterlocutor.cs
+++ b/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacionInterlocutor.cs
@@ -154,8 +154,8 @@ namespace VeriFactu.Business.Validation.Validators.Anulacion
                 {
 
                     // Si se identifica a través de la agrupación IDOtro y CodigoPais sea "ES", se validará que el campo IDType sea “03” o “07”..
-                    if (_Interlocutor.IDOtro.CodigoPais == CodigoPais.ES && 
-                        (_Interlocutor.IDOtro.IDType != IDType.PASAPORTE || _Interlocutor.IDOtro.IDType != IDType.NO_CENSADO))
+                    if (_Interlocutor.IDOtro.CodigoPais == CodigoPais.ES &&
+                        _Interlocutor.IDOtro.IDType != IDType.PASAPORTE && _Interlocutor.IDOtro.IDType != IDType.NO_CENSADO)
                         result.Add($"Error en el bloque RegistroAnulacion ({_RegistroAnulacion}):" +
                             $" {_Rol} es obligatorio que para IDOtro.CodigoPais = “{_Interlocutor.IDOtro.CodigoPais}”" +
                             $" IDOtro.IDType = “03” (PASAPORTE) o IDOtro.IDType = “07” (NO_CENSADO).");

--- a/NetCore/Src/Business/Validation/Validators/ValidatorSistemaInformatico.cs
+++ b/NetCore/Src/Business/Validation/Validators/ValidatorSistemaInformatico.cs
@@ -162,7 +162,7 @@ namespace VeriFactu.Business.Validation.Validators
 
                 // Si se identifica a través de la agrupación IDOtro y CodigoPais sea "ES", se validará que el campo IDType sea “03” o “07”..
                 if (sistemaInformatico.IDOtro.CodigoPais == CodigoPais.ES &&
-                    (sistemaInformatico.IDOtro.IDType != IDType.PASAPORTE || sistemaInformatico.IDOtro.IDType != IDType.NO_CENSADO))
+                    sistemaInformatico.IDOtro.IDType != IDType.PASAPORTE && sistemaInformatico.IDOtro.IDType != IDType.NO_CENSADO)
                     result.Add($"[0.0.2-0.9] Error en el bloque SistemaInformatico ({sistemaInformatico}):" +
                         $" Es obligatorio que para IDOtro.CodigoPais = “{sistemaInformatico.IDOtro.CodigoPais}”" +
                         $" IDOtro.IDType = “03” (PASAPORTE) o IDOtro.IDType = “07” (NO_CENSADO).");


### PR DESCRIPTION
Corrige la tautología de ValidatorSistemaInformatico [0.0.2-0.9] y la condición invertida del generador 'T' en anulación [3.1.4-3.4]. Defectos 3 y 4 de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes