### PR TITLE
Corregir validaciones de recargo de equivalencia, tipo impositivo 5% e IGIC en régimen simplificado

### DIFF
--- a/NetCore/Src/Business/Validation/Validators/Alta/Detalle/Regimen/ValidatorRegistroAltaDetalleDesgloseClaveRegimenRegimenSimplificado.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/Detalle/Regimen/ValidatorRegistroAltaDetalleDesgloseClaveRegimenRegimenSimplificado.cs
@@ -96,7 +96,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta.Detalle.Regimen
             // Si Impuesto = “03” (IGIC) y la ClaveRegimen es igual a “20” (Operaciones sujetas al IPSI – Valor adicional L8B),
             // CalificacionOperacion tiene que ser “N2” y siempre debe ir relleno.
 
-            if (_DetalleDesglose.Impuesto == Impuesto.IPSI)
+            if (_DetalleDesglose.Impuesto == Impuesto.IGIC)
             {
 
                 if(_DetalleDesglose.CalificacionOperacion != CalificacionOperacion.N2)

--- a/NetCore/Src/Business/Validation/Validators/Alta/Detalle/Regimen/ValidatorRegistroAltaDetalleDesgloseClaveRegimenRegimenSimplificadoIpsi.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/Detalle/Regimen/ValidatorRegistroAltaDetalleDesgloseClaveRegimenRegimenSimplificadoIpsi.cs
@@ -97,7 +97,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta.Detalle.Regimen
             // Si Impuesto = “03” (IGIC), el valor de ClaveRegimen debe estar contenido en la
             // lista L8B y adicionalmente puede contener el valor “21” (Régimen simplificado). 
 
-            if (_DetalleDesglose.Impuesto != Impuesto.IPSI)
+            if (_DetalleDesglose.Impuesto != Impuesto.IGIC)
                     result.Add($"[3.1.3-15.6.11.0] Error en el bloque RegistroAlta ({_RegistroAlta}) en el detalle {_DetalleDesglose}:" +
                              $" Si Impuesto = “03” (IGIC), el valor de ClaveRegimen debe estar contenido en la" +
                              $" lista L8B y adicionalmente puede contener el valor “21” (Régimen simplificado)." +

--- a/NetCore/Src/Business/Validation/Validators/Alta/Detalle/ValidatorRegistroAltaDetalleDesgloseTipoImpositivo.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/Detalle/ValidatorRegistroAltaDetalleDesgloseTipoImpositivo.cs
@@ -110,6 +110,11 @@ namespace VeriFactu.Business.Validation.Validators.Alta.Detalle
                 // ≥ 1 de octubre de 2024 y ≤ 31 de diciembre de 2024 se admitirá el TipoImpositivo = 2 y el TipoImpositivo = 7,5.
                 var allowedLastRates = fechaOperacion.CompareTo(new DateTime(2024, 10, 1)) >= 0 && fechaOperacion.CompareTo(new DateTime(2024, 12, 31)) <= 0;
 
+                // Las dos ventanas temporales son disjuntas, por lo que basta con
+                // sustituir la lista base por la de la ventana correspondiente.
+                if (allowedFive)
+                    allowedRates = new decimal[] { 0m, 4m, 5m, 10m, 21m };
+
                 if (allowedLastRates)
                     allowedRates = new decimal[] { 0m, 2m, 4m, 7.5m, 10m, 21m };
 

--- a/NetCore/Src/Business/Validation/Validators/Alta/Detalle/ValidatorRegistroAltaDetalleDesgloseTipoRecargoEquivalencia.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/Detalle/ValidatorRegistroAltaDetalleDesgloseTipoRecargoEquivalencia.cs
@@ -125,7 +125,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta.Detalle
                     case 21m:
 
                         // Si TipoImpositivo es 21 sólo se admitirán TipoRecargoEquivalencia = 5,2 ó 1,75.
-                        if (tipoImpositivoRE != 5.2m && tipoImpositivo != 1.75m)
+                        if (tipoImpositivoRE != 5.2m && tipoImpositivoRE != 1.75m)
                             result.Add($"[3.1.3-15.3.1] Error en el bloque RegistroAlta ({_RegistroAlta}) en el detalle {_DetalleDesglose}:" +
                                 $" Si TipoImpositivo es 21 sólo se admitirán TipoRecargoEquivalencia = 5,2 ó 1,75.");
 
@@ -180,7 +180,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta.Detalle
                             result.Add($"[3.1.3-15.3.5] Error en el bloque RegistroAlta ({_RegistroAlta}) en el detalle {_DetalleDesglose}:" +
                                     $" Si TipoImpositivo es 5 sólo se admitirá TipoRecargoEquivalencia = 0.5" +
                                     $" en el periodo igual o anterior a 31-12-2022.");
-                        else if (fechaOperacion.CompareTo(new DateTime(2023, 1, 1)) >= 0 && fechaOperacion.CompareTo(new DateTime(2024, 09, 30)) <= 0)
+                        else if (fechaOperacion.CompareTo(new DateTime(2023, 1, 1)) >= 0 && fechaOperacion.CompareTo(new DateTime(2024, 09, 30)) <= 0 && tipoImpositivoRE != 0.62m)
                             result.Add($"[3.1.3-15.3.6] Error en el bloque RegistroAlta ({_RegistroAlta}) en el detalle {_DetalleDesglose}:" +
                                     $" Si TipoImpositivo es 5 sólo se admitirá TipoRecargoEquivalencia = 0.62" +
                                     $" en el periodo del 01-01-2023 al 30-09-2024.");


### PR DESCRIPTION
Recargo de equivalencia (1,75% al 21% y 0,62% al 5%), ventana del tipo impositivo del 5% e IGIC (03) en lugar de IPSI (02) en régimen simplificado. Defectos 5, 6, 7 y 8 de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes