### PR TITLE
Corregir guardas de fecha en constructores de validadores (Alta y Anulación)

### DIFF
--- a/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAlta.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAlta.cs
@@ -109,7 +109,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta
 
             var fechaExpedicion = _RegistroAlta?.IDFacturaAlta?.FechaExpedicion;
 
-            if (string.IsNullOrEmpty(fechaExpedicion) && !Regex.IsMatch(fechaExpedicion, @"\d{2}-\d{2}-\d{4}"))
+            if (string.IsNullOrEmpty(fechaExpedicion) || !Regex.IsMatch(fechaExpedicion, @"^\d{2}-\d{2}-\d{4}$"))
                 throw new ArgumentException($"Error en el bloque RegistroAlta ({_RegistroAlta}):" +
                 $" La propiedad IDFactura.FechaExpedicion tiene que tener un valor con formato dd-mm-yyyy.");
 

--- a/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacion.cs
+++ b/NetCore/Src/Business/Validation/Validators/Anulacion/ValidatorRegistroAnulacion.cs
@@ -88,8 +88,8 @@ namespace VeriFactu.Business.Validation.Validators.Anulacion
 
             var fechaExpedicion = _RegistroAnulacion?.IDFacturaAnulada?.FechaExpedicion;
 
-            if (string.IsNullOrEmpty(fechaExpedicion) && !Regex.IsMatch(fechaExpedicion, @"\d{2}-\d{2}-\d{4}"))
-                throw new ArgumentException($"Error en el bloque RegistroAlta ({_RegistroAnulacion}):" +
+            if (string.IsNullOrEmpty(fechaExpedicion) || !Regex.IsMatch(fechaExpedicion, @"^\d{2}-\d{2}-\d{4}$"))
+                throw new ArgumentException($"Error en el bloque RegistroAnulacion ({_RegistroAnulacion}):" +
                 $" La propiedad IDFactura.FechaExpedicion tiene que tener un valor con formato dd-mm-yyyy.");
 
             _FechaExpedicion = FromXmlDate(fechaExpedicion);


### PR DESCRIPTION
La guarda usaba && donde debía usar ||: una fecha malformada esquivaba la validación y una nula lanzaba NullReferenceException en vez de ArgumentException. Defecto 9 de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes