### PR TITLE
Acotar la desactivación de la comprobación de revocación al handler de la AEAT

### DIFF
--- a/NetCore/Src/Net/Wsd.cs
+++ b/NetCore/Src/Net/Wsd.cs
@@ -236,10 +236,13 @@ namespace VeriFactu.Net
 
             socketsHttpHandler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
             {
-                ClientCertificates = new X509CertificateCollection { cert }
+                ClientCertificates = new X509CertificateCollection { cert },
+                // Desactiva la comprobación de revocación SOLO para este handler.
+                // El AppContext.SetSwitch anterior la desactivaba para TODOS los
+                // SocketsHttpHandler del proceso anfitrión, no solo para la AEAT.
+                CertificateRevocationCheckMode = X509RevocationMode.NoCheck
             };
 
-            AppContext.SetSwitch("System.Net.Http.CheckCertificateRevocationList", false);
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", false);
             ServicePointManager.Expect100Continue = false;
 


### PR DESCRIPTION
La comprobación de revocación (CRL) se desactivaba con un AppContext a nivel de todo el proceso, no solo para la AEAT. Defecto 11 (seguridad) de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes