### PR TITLE
Corregir umbrales de validación y comprobación de duplicados de NIF

### DIFF
--- a/NetCore/Src/Business/Validation/NIF/NifValidation.cs
+++ b/NetCore/Src/Business/Validation/NIF/NifValidation.cs
@@ -204,19 +204,19 @@ namespace VeriFactu.Business.Validation.NIF
             {
 
                 // Comprobamos duplicados
-                if (result.ContainsKey(item.Nif)) 
+                if (result.ContainsKey(item.Nif))
                 {
 
-                    if (item.Resultado == "IDENTIFICADO" || responseEnvelope.Body.Contribuyentes[0].Resultado == "IDENTIFICADO-REVOCADO") 
+                    if (item.Resultado == "IDENTIFICADO" || item.Resultado == "IDENTIFICADO-REVOCADO")
                         throw new Exception($"El NIF {item.Nif} de {item.Nombre} tiene varios resultados en la respuesta de la AEAT." +
                             $" Uno de ellos da el error: {result[item.Nif]} y otro pasa la validación con Resultado='{item.Resultado}'.");
-                    
-                
-                } 
-                else 
+
+
+                }
+                else
                 {
 
-                    if (item.Resultado != "IDENTIFICADO" && responseEnvelope.Body.Contribuyentes[0].Resultado != "IDENTIFICADO-REVOCADO")
+                    if (item.Resultado != "IDENTIFICADO" && item.Resultado != "IDENTIFICADO-REVOCADO")
                         result.Add(item.Nif, $"Error en la validación del NIF {item.Nif} de {item.Nombre}. Si el NIF es" +
                             $" de una persona física es necesario que conste también el nombre" +
                             $" correcto para poderlo validar.");

--- a/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaMacrodato.cs
+++ b/NetCore/Src/Business/Validation/Validators/Alta/ValidatorRegistroAltaMacrodato.cs
@@ -83,7 +83,7 @@ namespace VeriFactu.Business.Validation.Validators.Alta
 
             // Campo obligatorio si ImporteTotal >= |100.000.000,00| (valor absoluto).
 
-            if (Math.Abs(XmlParser.ToDecimal(_RegistroAlta.ImporteTotal)) > 100000000m && 
+            if (Math.Abs(XmlParser.ToDecimal(_RegistroAlta.ImporteTotal)) >= 100000000m &&
                 (_RegistroAlta.Macrodato == null || _RegistroAlta.Macrodato == "N"))
                 result.Add($"[3.1.3-10.0] Error en el bloque RegistroAlta ({_RegistroAlta}):" +
                         $" El campo Macrodato debe contener el valor 'S' obligatoriamente" +

--- a/NetCore/Src/Business/Validation/Validators/ValidatorRegistroFactura.cs
+++ b/NetCore/Src/Business/Validation/Validators/ValidatorRegistroFactura.cs
@@ -121,7 +121,7 @@ namespace VeriFactu.Business.Validation.Validators
 
             var result = new List<string>();
 
-            if (_RegFactuSistemaFacturacion.RegistroFactura.Count > 10000)
+            if (_RegFactuSistemaFacturacion.RegistroFactura.Count > 1000)
                 result.Add($"[3.1.2-1.0] La colección RegFactuSistemaFacturacion.RegistroFactura" +
                     $" contiene {_RegFactuSistemaFacturacion.RegistroFactura.Count}" +
                     $" elementos cuando sólo está permitido un máximo de 1000.");

--- a/NetCore/Src/Business/Validation/Validators/ValidatorSistemaInformatico.cs
+++ b/NetCore/Src/Business/Validation/Validators/ValidatorSistemaInformatico.cs
@@ -202,7 +202,7 @@ namespace VeriFactu.Business.Validation.Validators
 
             var result = new List<string>();
 
-            if (_RegFactuSistemaFacturacion.RegistroFactura.Count > 10000)
+            if (_RegFactuSistemaFacturacion.RegistroFactura.Count > 1000)
                 result.Add($"[0.0.2-0.10] La colección RegFactuSistemaFacturacion.RegistroFactura" +
                     $" contiene {_RegFactuSistemaFacturacion.RegistroFactura.Count}" +
                     $" elementos cuando sólo está permitido un máximo de 1000.");


### PR DESCRIPTION
Macrodato en la frontera exacta de 100.000.000 (>= en vez de >), umbrales (> 10000 donde el máximo es 1000) y duplicado de NIF que leía Contribuyentes[0] en lugar del elemento del bucle. Defecto número 12 y correcciones menores de #277. Reproducción: https://github.com/Rukko/verifactu-bugfixes