### PR TITLE
Evitar NullReferenceException al reintentar envíos de anulación

### DIFF
--- a/NetCore/Src/Business/InvoiceRetrySend.cs
+++ b/NetCore/Src/Business/InvoiceRetrySend.cs
@@ -142,14 +142,14 @@ namespace VeriFactu.Business
             if (registro == null)
                 throw new Exception($"No se ha encontrado el RegistroAlta / RegistroAnulacion correspondiente a la entrada {this}.");
 
-            var refExt = (registro as RegistroAlta).RefExterna?? (registro as RegistroAnulacion).RefExterna;
+            var refExt = (registro as RegistroAlta)?.RefExterna ?? (registro as RegistroAnulacion)?.RefExterna;
 
             if (string.IsNullOrEmpty(refExt))
                 throw new Exception($"No se ha encontrado el RefExterna correspondiente a la entrada {this}.");
 
             registro.BlockchainLinkID = Convert.ToUInt64(refExt);
 
-            var fechaHoraHusoGenRegistro = (registro as RegistroAlta).OrderedFechaHoraHusoGenRegistro ?? (registro as RegistroAnulacion).OrderedFechaHoraHusoGenRegistro;
+            var fechaHoraHusoGenRegistro = (registro as RegistroAlta)?.OrderedFechaHoraHusoGenRegistro ?? (registro as RegistroAnulacion)?.OrderedFechaHoraHusoGenRegistro;
 
             if (string.IsNullOrEmpty(fechaHoraHusoGenRegistro))
                 throw new Exception($"No se ha encontrado el OrderedFechaHoraHusoGenRegistro correspondiente a la entrada {this}.");


### PR DESCRIPTION
InvoiceRetrySend lanzaba NullReferenceException al reintentar una anulación. Corresponde al NRE mencionado en #277 (no es un caso del repro). Reproducción: https://github.com/Rukko/verifactu-bugfixes