### PR TITLE
Deserializar el nodo RegistroDuplicado en las líneas de respuesta

### DIFF
--- a/NetCore/Src/Xml/Factu/Respuesta/RespuestaLinea.cs
+++ b/NetCore/Src/Xml/Factu/Respuesta/RespuestaLinea.cs
@@ -87,6 +87,16 @@ namespace VeriFactu.Xml.Factu.Respuesta
         /// </summary>
         public string DescripcionErrorRegistro { get; set; }
 
+        /// <summary>
+        /// Información del registro comunicado anteriormente. Solo en el
+        /// caso de que se rechace el registro por duplicado, la AEAT
+        /// devuelve este nodo con los datos del registro ya existente
+        /// en el sistema (identificador de la petición anterior y estado
+        /// en el que se encuentra dicho registro).
+        /// </summary>
+        [XmlElement(Namespace = Namespaces.NamespaceTikR)]
+        public RegistroDuplicado RegistroDuplicado { get; set; }
+
         #endregion
 
         #region Métodos Públicos de Instancia


### PR DESCRIPTION
Buenas,

`RespuestaSuministro.xsd` define en `RespuestaExpedidaType` un último elemento opcional `RegistroDuplicado`, que la AEAT devuelve al rechazar un registro por duplicado con los datos del registro ya existente (identificador de la petición anterior y su estado). La clase `RegistroDuplicado` ya existe en la librería, pero `RespuestaLinea` no la mapea, así que esa información se pierde al deserializar.

Nos importa para reconciliar reintentos: cuando un envío llega a la AEAT pero la respuesta se pierde, el reintento rebota como duplicado, y este nodo es la señal que el esquema prevé para ese caso (más robusta que depender del código de error 3000).

**El cambio**: una propiedad nueva en `RespuestaLinea`, en la posición que marca la secuencia del XSD (tras `DescripcionErrorRegistro`) y con el mismo patrón de namespaces que ya usa `IDFactura` en esa clase:

```csharp
[XmlElement(Namespace = Namespaces.NamespaceTikR)]
public RegistroDuplicado RegistroDuplicado { get; set; }
```

Si el nodo no viene, la propiedad queda a `null`: sin cambios de comportamiento para nadie.

**Cómo lo hemos verificado**

- `dotnet build` de `VeriFactu.Net.Core.csproj` (net8.0).
- Round-trip con `Envelope.FromXml` sobre respuestas reales del entorno de pruebas de la AEAT: sin el nodo la propiedad queda a `null`; con el nodo presente, `IdPeticionRegistroDuplicado` y `EstadoRegistroDuplicado` se rellenan correctamente.
- Contra una respuesta real de duplicado: reenviamos al entorno de pruebas un registro ya registrado y la AEAT lo rechazó con el código 3000 y el nodo `RegistroDuplicado` relleno (estado `Correcta`, más el identificador de la petición original), exactamente como anuncia el esquema. Con este cambio la deserialización lo captura, y sin él, esa información se descarta.

¡Un saludo!
